### PR TITLE
Fix core plugin not working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,7 +319,7 @@ jar {
       'Built-On-Java': "${System.getProperty('java.vm.version')} (${System.getProperty('java.vm.vendor')})",
       'Built-On': "${project.mc_version}-${project.forge_version}"
     )
-    if (project.hasProperty('coreplugin')) {
+    if (project.hasProperty('core_plugin')) {
       attributes 'FMLCorePluginContainsFMLMod': 'true'
       attributes 'FMLCorePlugin': project.core_plugin
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ cf_use_custom_display_name = true
 #List of included dependencies (comma separated list)
 #cf_includes = 
 
-#String reference to coreplugin this mod contains, if any
+#String reference to Core Plugin this mod contains, if any
 #core_plugin = 
 #Whether or not to use Access Transformers from depended mods
 dep_has_ats = false


### PR DESCRIPTION
`coreplugin` -> `core_plugin` in build.gradle to make everything work
`core_plugin` -> `Core Plugin` in gradle.properties description to eliminate any confusion