### PR TITLE
Moved line length check so it works in IntelliJ.

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -12,6 +12,10 @@ Checkstyle configuration that checks the sun coding conventions.
 <module name="Checker">
   <property name="severity" value="warning"/>
   <property name="fileExtensions" value="java, properties, xml"/>
+  <module name="LineLength">
+    <property name="max" value="120"/>
+    <property name="tabWidth" value="4"/>
+  </module>
   <module name="TreeWalker">
     <module name="JavadocMethod"/>
     <module name="JavadocType"/>
@@ -31,10 +35,6 @@ Checkstyle configuration that checks the sun coding conventions.
     <module name="RedundantImport"/>
     <module name="UnusedImports">
       <property name="processJavadoc" value="false"/>
-    </module>
-    <module name="LineLength">
-      <property name="max" value="120"/>
-      <property name="tabWidth" value="4"/>
     </module>
     <module name="MethodLength"/>
     <module name="ParameterNumber"/>


### PR DESCRIPTION
When line length is within the TreeWalker module IntelliJ says there is an issue with the configuration, moving it out of that module fixes the issue.